### PR TITLE
Corrected README to reflect that 'repo_name' is a required parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,16 @@ Once you have a Shamer instance up and running, it is very easy to integrate the
 
 To submit your coverage percentages to Shamer, make a GET request to the `/hook/<pull_request_id>/<path:object_key>` endpoint. The `pull_request_id` is either the number of the PR, or the name of the branch for that PR. The `object_key` is the path to the coverage report on your S3 bucket. You must also include the following query parameters.
 
+- `repo_name`: The name of your GitHub repository
 - `build_id`: A unique identifier, often provided by your CI system
 - `commit_id`: The commit hash that these coverage percentages are for
 
 The final query parameters are the percentages of coverage for each language, identified by the comma-separated file extensions you entered during setup.
 
-Here is an example request for a project that has both Ruby and JavaScript code, where `123` is the `pull_request_id`, and `xyz/coverage/index.html` is the `object_key`.
+Here is an example request for a project that has both Ruby and JavaScript code, where `my_repo` is the `repo_name`, `123` is the `pull_request_id`, and `xyz/coverage/index.html` is the `object_key`.
 
 ```
-GET http://shamer.herokuapp.com/hook/123/xyz/coverage/index.html?build_id=1861574&commit_id=9a98f3bb8dbe23e60f1c1bfb2191a242910b2ea1&js=33.66&rb=57.68
+GET http://shamer.herokuapp.com/hook/123/xyz/coverage/index.html?repo_name=my_repo&build_id=1861574&commit_id=9a98f3bb8dbe23e60f1c1bfb2191a242910b2ea1&js=33.66&rb=57.68
 ```
 
 ##Customization


### PR DESCRIPTION
/hook/ requires the 'repo_name' parameter. Failure to include it results in a 'no repo name' status:

``` python
@app.route('/hook/<pull_request_id>/<path:object_key>')
def hook_view(pull_request_id, object_key):
  repo_name = request.args.get('repo_name')
  if not repo_name:
    return jsonify({'status': 'no repo name'})
...
```
