### PR TITLE
upgrade pymongo to 3.2.2, log URI when connecting

### DIFF
--- a/helpers/sources/mongo.py
+++ b/helpers/sources/mongo.py
@@ -1,7 +1,9 @@
+import logging
 from pymongo import MongoClient
 
 class MongoConstants():
   def __init__(self, collection_name, mongo_uri):
+    logging.info('Connecting to Mongo DB %s', mongo_uri)
     self.client = MongoClient(mongo_uri)
     db = mongo_uri.split('/')[-1]
     self.collection = self.client[db][collection_name]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Werkzeug==0.9.6
 boto==2.29.1
 gunicorn==19.0.0
 itsdangerous==0.24
-pymongo==2.7.1
+pymongo==3.2.2
 requests==2.3.0
 termcolor==1.1.0
 wsgiref==0.1.2


### PR DESCRIPTION
MongoLab now evidently uses v3, which made a backward incompatible change to the auth protocol, so we need a v3 client to connect.

btw, thanks for making shamer! we're using it at our work now and really enjoying it. i had to make a number of small changes to get it running, so i'm going to try to send PRs for each of them individually. feel free to accept or reject any of them. thanks again!