### PR TITLE
add Coveralls support with new /coveralls endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ from helpers.githubbot import GithubBot
 from helpers.sources.osenv import OSConstants
 from helpers.sources.mongo import MongoConstants
 from helpers.extensions import LanguageExtensions
-import os, time, datetime
+import os, time, datetime, logging
 
 app = Flask(__name__)
 dev = os.environ.get('dev') == 'true' or not os.environ.get('PORT')
@@ -135,34 +135,62 @@ def callback_view():
     return redirect(session.pop('next'))
   return redirect(url_for('demo_view'))
 
-@app.route('/hook/<pull_request_id>/<path:object_key>')
-def hook_view(pull_request_id, object_key):
-  repo_name = request.args.get('repo_name')
+def hook(args):
+  repo_name = args.get('repo_name')
   if not repo_name:
     return jsonify({'status': 'no repo name'})
   bot = bots.get(repo_name)
   storage = storages.get(repo_name)
   if bot:
-    if not pull_request_id.isdigit():
-      # pull_request_id is the branch name
+    if not args['pull_request_id'].isdigit():
+      # args['pull_request_id'] is the branch name
       if storage:
-        args = request.args.copy().to_dict()
         commit = args.pop('commit_id')
         if commit:
-          value = storage.get(pull_request_id, {})
+          value = storage.get(args['pull_request_id'], {})
           value[commit] = args
           value['current'] = args
-          storage.set(pull_request_id, value)
+          storage.set(args['pull_request_id'], value)
       try:
-        pull_request_id = bot.get_pr_by_branch(pull_request_id).number
+        args['pull_request_id'] = bot.get_pr_by_branch(args['pull_request_id']).number
       except:
         return jsonify({'status': 'no such pull request'})
-    url = url_for('go_view', object_key=object_key, _external=True)
-    if bot.process_hook(int(pull_request_id), url, request.args, storage):
+    url = url_for('go_view', object_key=args.get('object_key', ''), _external=True)
+    if bot.process_hook(int(args['pull_request_id']), url, args, storage):
       return jsonify({'status': 'success'})
     else:
       return jsonify({'status': 'restarting'})
   return jsonify({'status': 'no bot credentials'})
+
+@app.route('/hook/<pull_request_id>/<path:object_key>')
+def hook_view(pull_request_id, object_key):
+    args = request.args.copy().to_dict()
+    args.update({
+      'pull_request_id': pull_request_id,
+      'object_key': object_key,
+    })
+    return hook(args)
+
+@app.route('/coveralls', methods=['POST'])
+def coveralls_view():
+  try:
+    commit_sha = request.values['commit_sha']
+    repo_name = request.values['repo_name'].split('/')[-1]
+    lang = LANGS[repo_name]
+    assert ',' not in lang
+
+    pr = bots[repo_name].get_pr_by_commit(commit_sha)
+
+    return hook({
+      'repo_name': repo_name,
+      'commit_id': commit_sha,
+      # 'build_id': commit_sha,
+      'pull_request_id': str(pr.number) if pr else '',
+      lang: request.values.get('coverage_change', 0),
+      # no build id available :(
+    })
+  except:
+    logging.exception('Failed coveralls')
 
 @app.route('/')
 def demo_view():


### PR DESCRIPTION
Coveralls (http://coveralls.io/) can send a webhook when it has new coverage data for a change: https://coveralls.zendesk.com/hc/en-us/articles/201774895-Notifications

this adds support for that with a new /coveralls endpoint. it's mostly the same as the /hook/... endpoint, and reuses most of the code, but looks up the GitHub PR based on the commit hash.

it also mildly refactors GithubBot.process_hook a bit to allow unset build_id, since Coveralls doesn't send one in its webhook.