### PR TITLE
add new boolean GH_COMMENT env var for whether to post GitHub comments

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,6 +11,7 @@ GH_SECRET=moresecrets
 GH_ORG=29205
 GH_ORG_NAME=localytics
 GH_REPOS=repo1,repo2
+GH_COMMENT=true
 LANGS=rb,js;rb
 MODE=proxy
 MONGO_URI=mongodb://heroku_appxyz:abcd@ds031978.mongolab.com:31978/heroku_appxyz

--- a/app.json
+++ b/app.json
@@ -43,6 +43,10 @@
     "GH_REPOS": {
       "description": "Comma-separated Github repo names to track coverage for"
     },
+    "GH_COMMENT": {
+      "description": "Whether to comment on GitHub PRs",
+      "value": "true"
+    },
     "LANGS": {
       "description": "Comma-separated language file extensions (such as rb,js) to collect coverage for (semicolon-separated for multiple repos, one per repo)"
     },

--- a/app.py
+++ b/app.py
@@ -18,10 +18,12 @@ extensions = LanguageExtensions()
 LANGS = dict(zip(constants.get('GH_REPOS').split(','), constants.get('LANGS').split(';')))
 CURRENT = dict(zip(constants.get('GH_REPOS').split(','), constants.get('CURRENT').split(';')))
 
-try:
-  s3 = S3(constants.get('AWS_ACCESS_KEY'), constants.get('AWS_SECRET_KEY'), constants.get('AWS_BUCKET'))
-except:
-  s3 = None
+s3 = None
+if constants.get('GH_COMMENT').lower() == 'true':
+  try:
+    s3 = S3(constants.get('AWS_ACCESS_KEY'), constants.get('AWS_SECRET_KEY'), constants.get('AWS_BUCKET'))
+  except:
+    pass
 
 collections = zip(constants.get('GH_REPOS').split(','), constants.get('STORAGE_COLLECTIONS').split(','))
 storages = {}
@@ -50,7 +52,7 @@ def preprocess_request():
       return redirect(url_for('login_view'))
     if session.get('next'):
       return redirect(session.pop('next'))
-    if not s3:
+    if constants.get('GH_COMMENT').lower() == 'true' and not s3:
       flash('Your S3 keys are invalid!', 'danger')
       return 'Your S3 keys are invalid!'
 

--- a/helpers/githubbot.py
+++ b/helpers/githubbot.py
@@ -96,11 +96,12 @@ class GithubBot():
     self.post_comment(body, pr)
 
   def post_comment(self, body, pr):
-    past_comment = self.past_comment(pr)
-    if past_comment:
-      past_comment.edit(body)
-    else:
-      pr.create_issue_comment(body)
+    if self.constants.get('GH_COMMENT').lower() == 'true':
+      past_comment = self.past_comment(pr)
+      if past_comment:
+        past_comment.edit(body)
+      else:
+        pr.create_issue_comment(body)
 
   def get_pr_by_branch(self, branch_name):
     cached = self.cache['prs'].get(branch_name)

--- a/helpers/githubbot.py
+++ b/helpers/githubbot.py
@@ -14,6 +14,7 @@ class GithubBot():
     self.current = current.split(',')
     self.constants = constants
     self.cache = defaultdict(dict)
+    self.post_comments = constants.get('GH_COMMENT').lower() == 'true'
 
   def past_comment(self, pr):
     cached = self.cache['comments'].get(pr.id)
@@ -96,12 +97,14 @@ class GithubBot():
     self.post_comment(body, pr)
 
   def post_comment(self, body, pr):
-    if self.constants.get('GH_COMMENT').lower() == 'true':
-      past_comment = self.past_comment(pr)
-      if past_comment:
-        past_comment.edit(body)
-      else:
-        pr.create_issue_comment(body)
+    if not self.post_comments:
+      return
+
+    past_comment = self.past_comment(pr)
+    if past_comment:
+      past_comment.edit(body)
+    else:
+      pr.create_issue_comment(body)
 
   def get_pr_by_branch(self, branch_name):
     cached = self.cache['prs'].get(branch_name)


### PR DESCRIPTION
this is useful because we just use Shamer as a leaderboard that aggregates coverage contributions by user. we use Coveralls to collect and track coverage over time, which is great, so we don't need Shamer for that. setting this new env var to false lets us skip the GitHub comments, since Coveralls is already a status check on our GitHub PRs, and also lets us avoid storing coverage data in AWS at all.
